### PR TITLE
add ability to enable/disable account

### DIFF
--- a/api/src/api-models/user.ts
+++ b/api/src/api-models/user.ts
@@ -1,5 +1,6 @@
 export interface InputUser {
   publicId: string;
   email: string;
-  syndications: string[];
+  syndications?: string[];
+  enabled?: boolean;
 }

--- a/api/src/db-models/user.ts
+++ b/api/src/db-models/user.ts
@@ -6,6 +6,7 @@ export interface IUser extends Document {
   publicId: string;
   email?: string | null;
   verified: boolean;
+  enabled: boolean;
   syndications: ISyndication[];
   lastEmailedComics?: IComic[];
   verificationHash: string;
@@ -20,6 +21,7 @@ const userSchema = new Schema(
     publicId: String,
     email: String,
     verified: Boolean,
+    enabled: Boolean,
     syndications: [
       {
         type: Schema.Types.ObjectId,

--- a/api/src/router/email.ts
+++ b/api/src/router/email.ts
@@ -40,6 +40,9 @@ export const resolvers = {
       if (!user.verified) {
         throw new UserInputError(`User "${email}" is not verified.`);
       }
+      if (!user.enabled) {
+        throw new UserInputError(`User "${email}" is disabled.`);
+      }
       let messageIds: (string | null)[] = [];
       try {
         messageIds = await emailUsers([user], options, date);

--- a/api/src/router/user.ts
+++ b/api/src/router/user.ts
@@ -16,10 +16,12 @@ export const typeDefs = gql`
     publicId: ID
     email: String
     syndications: [String]
+    enabled: Boolean
   }
   type User {
     email: String
     verified: Boolean!
+    enabled: Boolean!
     syndications: [Syndication]!
     emails: [Email]!
     publicId: ID!
@@ -79,6 +81,7 @@ export const resolvers = {
         email,
         publicId,
         verified: false,
+        enabled: true,
         syndications: [],
         verificationHash,
         googleAnalyticsHash,
@@ -97,6 +100,7 @@ export const resolvers = {
       return User.create({
         publicId,
         verified: false,
+        enabled: true,
         syndications: [],
         verificationHash,
         googleAnalyticsHash,
@@ -114,11 +118,13 @@ export const resolvers = {
       if (user == null) {
         throw invalidUserByPublicIdError(publicId);
       }
-      user.syndications = await Syndication.find({
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore type of identifier is wrong but appears to work?
-        identifier: inputUser.syndications,
-      }).exec();
+      if (inputUser.syndications != null) {
+        user.syndications = await Syndication.find({
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore type of identifier is wrong but appears to work?
+          identifier: inputUser.syndications,
+        }).exec();
+      }
       let inputEmail: string | null = null;
       if (inputUser.email != null) {
         inputEmail = inputUser.email.toLowerCase();
@@ -136,6 +142,9 @@ export const resolvers = {
           );
         }
         user.email = inputEmail;
+      }
+      if (inputUser.enabled != null) {
+        user.enabled = inputUser.enabled;
       }
       await user.save();
       const { email } = user;

--- a/api/src/service/email/comic-email-service.ts
+++ b/api/src/service/email/comic-email-service.ts
@@ -147,6 +147,7 @@ export const emailAllUsers = async (
   const { onlyIfWeHaventCheckedToday = true, limit = 50 } = options;
   let conditions: any = {
     verified: true,
+    enabled: true,
     email: { $exists: true, $ne: null },
   };
   if (onlyIfWeHaventCheckedToday) {

--- a/components/UserInfoBlock/AccountEnabledSection.tsx
+++ b/components/UserInfoBlock/AccountEnabledSection.tsx
@@ -1,0 +1,95 @@
+import { useMutation } from "@apollo/client";
+import gql from "graphql-tag";
+import React from "react";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { useToasts } from "react-toast-notifications";
+import { CommonLink } from "../../common-components/CommonLink/CommonLink";
+import { handleGraphQlResponse, toastType } from "../../lib/utils";
+import { H3 } from "../../common-components/H3/H3";
+import { DynamicText } from "../../common-components/DynamicText/DynamicText";
+
+interface Props {
+  enabled: boolean;
+  email: string;
+  publicId: string;
+  onSetNewEnabledValue: (newEnabledValue: boolean) => void;
+}
+
+type PutUserResult = {
+  enabled: boolean;
+};
+
+export const AccountEnabledSection = (props: Props) => {
+  const { enabled, publicId, onSetNewEnabledValue, email } = props;
+  const { addToast } = useToasts();
+
+  const mutation = gql`
+    mutation putUser($publicId: String!, $user: InputUser!) {
+      putUser(publicId: $publicId, user: $user) {
+        enabled
+      }
+    }
+  `;
+  const [putUserMutation] = useMutation<PutUserResult>(mutation);
+  const updatedEnabledStatus = async (newEnabledValue: boolean) => {
+    return handleGraphQlResponse(
+      putUserMutation({
+        variables: {
+          publicId,
+          user: {
+            email,
+            publicId,
+            enabled: newEnabledValue,
+          },
+        },
+      }),
+    );
+  };
+
+  if (!enabled) {
+    return (
+      <H3>
+        However, your account is <DynamicText>disabled</DynamicText>, so you
+        won&apos;t receive any more emails from us.{" "}
+        <CommonLink
+          onClick={async () => {
+            onSetNewEnabledValue(true);
+            const result = await updatedEnabledStatus(true);
+            if (result.success) {
+              addToast(`Account is now enabled.`, toastType.success);
+            } else {
+              addToast(
+                `Could not enable account: ${result.combinedErrorMessage}`,
+                toastType.error,
+              );
+            }
+          }}
+        >
+          Re-enable it.
+        </CommonLink>
+      </H3>
+    );
+  }
+  return (
+    <H3>
+      Your account is <DynamicText>enabled</DynamicText>.{" "}
+      <CommonLink
+        onClick={async () => {
+          onSetNewEnabledValue(false);
+          const result = await updatedEnabledStatus(false);
+          if (result.success) {
+            addToast(`Account is now disabled.`, toastType.success);
+          } else {
+            addToast(
+              `Could not disable account: ${result.combinedErrorMessage}`,
+              toastType.error,
+            );
+          }
+        }}
+      >
+        Disable it.
+      </CommonLink>
+    </H3>
+  );
+};

--- a/components/UserInfoBlock/UserInfoBlock.tsx
+++ b/components/UserInfoBlock/UserInfoBlock.tsx
@@ -1,0 +1,171 @@
+import React, { useState } from "react";
+import { H3 } from "../../common-components/H3/H3";
+import { DynamicText } from "../../common-components/DynamicText/DynamicText";
+import { formattedComicDeliveryTime } from "../../lib/utils";
+import { CommonLink } from "../../common-components/CommonLink/CommonLink";
+import { ResendTodaysEmailLink } from "../ResendEmailLink/ResendTodaysEmailLink";
+import { ResendVerificationEmailLink } from "../ResendEmailLink/ResendVerificationEmailLink";
+import { AccountEnabledSection } from "./AccountEnabledSection";
+
+export interface Email {
+  messageId: string;
+  sendTime: Date;
+}
+
+interface Props {
+  verified: boolean;
+  enabled: boolean;
+  email: string;
+  publicId: string;
+  emails: Email[] | undefined;
+  selectedSyndications: Set<string> | null;
+  isNewUser: boolean;
+}
+
+export const UserInfoBlock = (props: Props) => {
+  const {
+    verified,
+    enabled: currentEnabledValue,
+    email,
+    publicId,
+    emails = [],
+    selectedSyndications,
+    isNewUser,
+  } = props;
+
+  const [newEnabledValue, setNewEnabledValue] = useState<boolean | undefined>();
+  // Optimistically update UI as soon as a new enabled value is set.
+  const enabled =
+    newEnabledValue != null ? newEnabledValue : currentEnabledValue;
+
+  // First, check if the user is a new user who has just completed registration.
+  // If so, we can assume that the user is enabled but not verified and display
+  // the same message without checking anything else.
+  if (isNewUser) {
+    return (
+      <>
+        <H3>
+          A verification email was just sent to{" "}
+          <DynamicText>{email}</DynamicText>.
+        </H3>
+        <H3>
+          <ResendVerificationEmailLink email={email} />
+        </H3>
+        <H3>You&apos;ll receive comics once you verify your email.</H3>
+      </>
+    );
+  }
+  // If they are not a new user, the next thing we check is whether the user's
+  // email is verified. If not, we simply ask them to verify their email.
+  //
+  // Since we assume users only go from unverified to verified, we do not need
+  // to consider any other cases (i.e. whether the user is "enabled" or not,
+  // because we have never given them the option to disable it, or whether the
+  // user has received any past emails or not, because we assume they haven't).
+  if (!verified) {
+    return (
+      <>
+        <H3>
+          Your email address is <DynamicText>not verified</DynamicText>.
+        </H3>
+        <H3>
+          Until you verify your email, you will not receive comics (or any other
+          emails from our service).
+        </H3>
+        <H3>
+          <ResendVerificationEmailLink email={email} />
+        </H3>
+      </>
+    );
+  }
+
+  // By this point, the user is verified. All info text should be prepended with
+  // information saying so.
+  let infoBlock = (
+    <>
+      <H3>
+        Your email address is <DynamicText>verified</DynamicText>.
+      </H3>
+    </>
+  );
+
+  const uriEncodedEmail = encodeURIComponent(email);
+  const pastEmailsBlock = (
+    <>
+      {emails.length > 0 && (
+        <H3>
+          <CommonLink href={`/user/emails?email=${uriEncodedEmail}`}>
+            View past emails.
+          </CommonLink>
+        </H3>
+      )}
+    </>
+  );
+
+  // At this point, we should also display the AccountEnabledSection which
+  // handles telling the user whether their account is enabled or not and
+  // allowing them to change it.
+  infoBlock = (
+    <>
+      {infoBlock}
+      <AccountEnabledSection
+        publicId={publicId}
+        enabled={enabled}
+        onSetNewEnabledValue={setNewEnabledValue}
+        email={email}
+      />
+    </>
+  );
+
+  if (!enabled) {
+    // If the user isn't enabled, return info block and past emails block since
+    // any further information won't matter.
+    return (
+      <>
+        {infoBlock} {pastEmailsBlock}
+      </>
+    );
+  }
+
+  if (selectedSyndications == null) {
+    // selectedSyndications hasn't loaded yet. Return info block unchanged as a
+    // generic message until selectedSyndications loads.
+    return (
+      <>
+        {infoBlock} {pastEmailsBlock}
+      </>
+    );
+  }
+  if (selectedSyndications.size === 0) {
+    return (
+      <>
+        {infoBlock}
+        <H3>
+          However, you are not subscribed to any comics, so you will{" "}
+          {emails.length > 0 ? "no longer " : "not "}
+          receive any emails. Subscribe to some below in order to receive comics
+          every day.
+        </H3>
+        {pastEmailsBlock}
+      </>
+    );
+  }
+  // At this point, the user's account is verified, enabled, and they subscribe
+  // to at least one comic.
+  return (
+    <>
+      {infoBlock}
+      <H3>
+        You will get an email at{" "}
+        <DynamicText>{formattedComicDeliveryTime()}</DynamicText> every day.
+      </H3>
+      {pastEmailsBlock}
+      <H3>
+        <ResendTodaysEmailLink
+          email={email}
+          isFirstEmail={emails.length === 0}
+        />
+      </H3>
+    </>
+  );
+};

--- a/pages/user/emails.tsx
+++ b/pages/user/emails.tsx
@@ -23,7 +23,6 @@ const EmailsPage: React.FunctionComponent = () => {
             userByEmail(email: "${email}") {
                 email
                 publicId
-                verified
                 emails {
                     messageId
                     sendTime

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -3,27 +3,20 @@ import gql from "graphql-tag";
 import React, { useState } from "react";
 import { DynamicText } from "../../common-components/DynamicText/DynamicText";
 import { Layout } from "../../common-components/Layout/Layout";
-import { ResendVerificationEmailLink } from "../../components/ResendEmailLink/ResendVerificationEmailLink";
 import { SyndicationEditor } from "../../components/SyndicationEditor/SyndicationEditor";
-import {
-  formattedComicDeliveryTime,
-  stringifyGraphQlError,
-  useUrlQuery,
-} from "../../lib/utils";
+import { stringifyGraphQlError, useUrlQuery } from "../../lib/utils";
 import styles from "./index.module.scss";
 import { H3 } from "../../common-components/H3/H3";
-import { CommonLink } from "../../common-components/CommonLink/CommonLink";
-import { ResendTodaysEmailLink } from "../../components/ResendEmailLink/ResendTodaysEmailLink";
-
-interface Email {
-  messageId: string;
-  sendTime: Date;
-}
+import {
+  Email,
+  UserInfoBlock,
+} from "../../components/UserInfoBlock/UserInfoBlock";
 
 interface User {
   email: string;
   publicId: string;
   verified: boolean;
+  enabled: boolean;
   emails?: Email[];
 }
 
@@ -54,6 +47,7 @@ const UserPage: React.FunctionComponent = () => {
           email
           publicId
           verified
+          enabled
           emails {
             messageId
           }
@@ -67,6 +61,7 @@ const UserPage: React.FunctionComponent = () => {
           email
           publicId
           verified
+          enabled
           emails {
             messageId
           }
@@ -86,84 +81,8 @@ const UserPage: React.FunctionComponent = () => {
   if (loading || !data || (!data.userByPublicId && !data.userByEmail)) {
     return <Layout title="Loading..." isLoading />;
   }
-  const { verified, email, publicId, emails = [] } =
+  const { verified, enabled, email, publicId, emails = [] } =
     data.userByPublicId || data.userByEmail;
-
-  let infoBlock = null;
-  if (verified) {
-    if (selectedSyndications == null) {
-      // selectedSyndications hasn't loaded yet. Display a generic message.
-      infoBlock = (
-        <H3>
-          Your email address is <DynamicText>verified</DynamicText>.
-        </H3>
-      );
-    } else if (selectedSyndications.size === 0) {
-      infoBlock = (
-        <>
-          <H3>
-            Your email address is <DynamicText>verified</DynamicText>.
-          </H3>
-          <H3>
-            However, you are not subscribed to any comics, so you will not
-            receive any emails. Subscribe to some below in order to receive
-            comics every day.
-          </H3>
-        </>
-      );
-    } else {
-      const uriEncodedEmail = encodeURIComponent(email);
-      infoBlock = (
-        <>
-          <H3>
-            Your email address is <DynamicText>verified</DynamicText>.
-          </H3>
-          <H3>
-            You will get an email at{" "}
-            <DynamicText>{formattedComicDeliveryTime()}</DynamicText> every day.
-          </H3>
-          {emails.length > 0 && (
-            <H3>
-              <CommonLink href={`/user/emails?email=${uriEncodedEmail}`}>
-                View past emails.
-              </CommonLink>
-            </H3>
-          )}
-          <H3>
-            <ResendTodaysEmailLink
-              email={email}
-              isFirstEmail={emails.length === 0}
-            />
-          </H3>
-        </>
-      );
-    }
-  } else if (isNewUser) {
-    infoBlock = (
-      <>
-        <H3>
-          A verification email was just sent to{" "}
-          <DynamicText>{email}</DynamicText>.
-        </H3>
-        <H3>
-          <ResendVerificationEmailLink email={email} />
-        </H3>
-        <H3>You&apos;ll receive comics once you verify your email.</H3>
-      </>
-    );
-  } else {
-    infoBlock = (
-      <>
-        <H3>
-          Your email address is <DynamicText>not verified</DynamicText>.
-        </H3>
-        <H3>Until you verify your email, you will not receive comics.</H3>
-        <H3>
-          <ResendVerificationEmailLink email={email} />
-        </H3>
-      </>
-    );
-  }
 
   return (
     <Layout title="My Account">
@@ -171,7 +90,15 @@ const UserPage: React.FunctionComponent = () => {
         <H3>
           Your email is <DynamicText>{email}</DynamicText>.
         </H3>
-        {infoBlock}
+        <UserInfoBlock
+          verified={verified}
+          enabled={enabled}
+          email={email}
+          publicId={publicId}
+          emails={emails}
+          selectedSyndications={selectedSyndications}
+          isNewUser={isNewUser}
+        />
       </div>
       <SyndicationEditor
         publicId={publicId}


### PR DESCRIPTION
Adds the ability to enable/disable accounts without having to remove all syndications. Can be used to add a one-click unsubscribe button in emails.