### PR TITLE
Standardize env variables and secrets per vercel 22.0, add staging en…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,8 @@ course).
    mongodb-community`.
 
 ### Prerequisites to starting server locally
-1. Create a `.env` file in the root directory. This file is not tracked in git
-   because it contains secrets. Put the following there as contents:
-```bash
-mongodb_url="mongodb://127.0.0.1:27017/ic"
-elasticemail_api_key="<get this from @elijahcarrel>"
-domain="http://localhost:3000"
-```
-   The `elasticemail_api_key` parameter is empty because it is the same as
-   production and therefore secret-- ask @elijahcarrel directly what the API key
-   is. The other information is local-specific and do not match the (secret)
-   production values.
+1. `$ vercel login`.
+1. Enter username and password to log into the inboxcomics Vercel team.
 
 ### Starting the app locally
 1. `$ vercel dev`.
@@ -89,4 +80,5 @@ domain="http://localhost:3000"
 
 ### Opening a production database console.
 1. The URL and password for the production database are, of course, secret. Ask
-   @elijahcarrel.
+   @elijahcarrel or find them at [the Vercel environment variables
+   settings](https://vercel.com/inboxcomics/app/settings/environment-variables).

--- a/vercel.json
+++ b/vercel.json
@@ -4,11 +4,6 @@
     { "src": "package.json", "use": "@vercel/next" },
     { "src": "api/src/index.ts", "use": "@vercel/node" }
   ],
-  "env": {
-    "mongodb_url": "@mongodb_url",
-    "elasticemail_api_key": "@elasticemail_api_key",
-    "domain": "https://www.inboxcomics.com"
-  },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/src/index.ts" }
   ]


### PR DESCRIPTION
…vironment

- Rather than having env variables tracked in different ways for
  local dev vs production, we use Vercel's new cohesive environment
  variable tracking and get rid of some awkward code.
- This also enables us to add staging environment variables
  (different from both prod and localhost), so spun up a staging
  mongo instance to run on staging inboxcomics domain (finally lol,
  turns out it was v easy).
- Upgrade to Vercel 22.0.1.