### PR TITLE
Optimistically update users

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
A few times now, we've had database timeouts on writes. This has led to a situation where the cron job gets the first fifty users, sends them an email, tries to update the database to indicate that it's sent them an email, and then times out. The next minute, it does it again, with the same fifty users.

With this change, we've de-risked this by optimistically marking a user as "checked" in the database before we email them. This has its own potential failure mode-- if the lambda were to time out after marking a user as checked, but before emailing them, then the next iteration of the cron job will incorrectly skip that user.

However, we think this is less bad. Essentially, we've decided that under-emailing is better than over-emailing.