### PR TITLE
dilbert email is going out tomorrow now

### DIFF
--- a/api/src/service/email/templates/send-comic-email.ts
+++ b/api/src/service/email/templates/send-comic-email.ts
@@ -175,7 +175,7 @@ const customMessages: Record<string, string> = {
     Team Inbox Comics
 </p>
 `,
-  "February 27th, 2023": `
+  "February 29th, 2023": `
 <p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
     Hi all,
 </p>


### PR DESCRIPTION
It didn't go out Monday as planned because of the vercel deployment issue, now that that's fixed the blurb should go out tomorrow (Wednesday).