### PR TITLE
add ability to send data-driven news items in emails

### DIFF
--- a/api/src/api-models/email-options.ts
+++ b/api/src/api-models/email-options.ts
@@ -8,6 +8,8 @@ export interface EmailAllUsersOptions {
   // Only email each user if we haven't already tried to send them an email today ("tried" means that we
   // looked to see if they deserved an email and sent them one if they did). Default: true.
   onlyIfWeHaventCheckedToday?: boolean;
+  // If true, includes the latest news item even if it's already been sent to this user. Default: false.
+  includeLatestNewsItemEvenIfItsAlreadyBeenSent?: boolean;
 }
 
 export interface CancelThrottledEmailsOptions {

--- a/api/src/db-models/news-item.ts
+++ b/api/src/db-models/news-item.ts
@@ -5,6 +5,8 @@ export interface INewsItem extends Document {
   createTime: Date;
   headline: string;
   content: string;
+  emailContent: string;
+  isPublished: boolean;
 }
 
 const newsItemSchema = new Schema({
@@ -12,6 +14,8 @@ const newsItemSchema = new Schema({
   createTime: Date,
   headline: String,
   content: String,
+  emailContent: String,
+  isPublished: Boolean,
 });
 
 export const NewsItem = model<INewsItem>("newsitem", newsItemSchema);

--- a/api/src/db-models/user.ts
+++ b/api/src/db-models/user.ts
@@ -1,6 +1,7 @@
 import { Document, model, Schema } from "mongoose";
 import { IEmail } from "./email";
 import { ISyndication, IComic } from "./comic-syndication";
+import { INewsItem } from "./news-item";
 
 export interface IUser extends Document {
   publicId: string;
@@ -8,6 +9,7 @@ export interface IUser extends Document {
   verified: boolean;
   enabled: boolean;
   syndications: ISyndication[];
+  lastEmailedNewsItem?: INewsItem | null;
   lastEmailedComics?: IComic[];
   verificationHash: string;
   googleAnalyticsHash: string;
@@ -35,6 +37,10 @@ const userSchema = new Schema(
       },
     ],
     verificationHash: String,
+    lastEmailedNewsItem: {
+      type: Schema.Types.ObjectId,
+      ref: "newsitem",
+    },
     googleAnalyticsHash: String,
     lastEmailCheck: Date,
     lastEmailSent: Date,

--- a/api/src/router/email.ts
+++ b/api/src/router/email.ts
@@ -22,6 +22,7 @@ export const typeDefs = gql`
     limit: Int
     mentionNotUpdatedComics: Boolean
     onlyIfWeHaventCheckedToday: Boolean
+    includeLatestNewsItemEvenIfItsAlreadyBeenSent: Boolean
   }
   input CancelThrottledEmailsOptions {
     limit: Int

--- a/api/src/router/news-item.ts
+++ b/api/src/router/news-item.ts
@@ -23,7 +23,7 @@ export const typeDefs = gql`
 export const resolvers = {
   Query: {
     getNews: async () => {
-      return NewsItem.find().sort({ createTime: -1 }).exec();
+      return NewsItem.find({ isPublished: true }).sort({ createTime: -1 }).exec();
     },
     getNewsItem: async (_: any, args: { identifier: string }) => {
       const { identifier } = args;

--- a/api/src/service/email/comic-email-service.ts
+++ b/api/src/service/email/comic-email-service.ts
@@ -50,6 +50,7 @@ const isWorthSendingEmail = (
 const parseUsersInfoForEmail = (
   populatedUsers: IUser[],
   mostRecentNewsItem: INewsItem | null,
+  includeLatestNewsItemEvenIfItsAlreadyBeenSent: boolean,
 ): UserInfoForEmail[] => {
   return populatedUsers.map((populatedUser: IUser) => {
     const {
@@ -87,7 +88,8 @@ const parseUsersInfoForEmail = (
     if (mostRecentNewsItem !== null) {
       if (
         lastEmailedNewsItem == null ||
-        lastEmailedNewsItem.identifier !== mostRecentNewsItem.identifier
+        lastEmailedNewsItem.identifier !== mostRecentNewsItem.identifier ||
+        includeLatestNewsItemEvenIfItsAlreadyBeenSent
       ) {
         newsItem = {
           identifier: mostRecentNewsItem.identifier,
@@ -192,7 +194,7 @@ export const emailUsers = async (
   options: EmailAllUsersOptions,
   date: Moment,
 ) => {
-  const { sendAllComics = false, mentionNotUpdatedComics = true } = options;
+  const { sendAllComics = false, mentionNotUpdatedComics = true, includeLatestNewsItemEvenIfItsAlreadyBeenSent = false } = options;
   const populatedUsers: IUser[] = await User.populate(users, [
     {
       path: "syndications",
@@ -222,6 +224,7 @@ export const emailUsers = async (
   const usersInfoForEmail = parseUsersInfoForEmail(
     populatedUsers,
     mostRecentNewsItem,
+    includeLatestNewsItemEvenIfItsAlreadyBeenSent,
   );
 
   // Before attempting to send emails, we mark users as checked in the database.

--- a/api/src/service/email/templates/send-comic-email.ts
+++ b/api/src/service/email/templates/send-comic-email.ts
@@ -95,7 +95,7 @@ const generateHtmlForComic = (
 const formatEmailContentForNewsItem = (emailContent: string): string => {
   return emailContent.replace(
     /<p>/g,
-    "<p style=\"font - family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;\">",
+    "<p style=\"font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;\">",
   );
 };
 

--- a/api/src/service/email/templates/send-comic-email.ts
+++ b/api/src/service/email/templates/send-comic-email.ts
@@ -10,6 +10,11 @@ export interface ComicForEmail {
   imageCaption: string | null;
 }
 
+export interface NewsItemForEmail {
+  identifier: string;
+  emailContent: string;
+}
+
 export interface SendComicEmailOptions {
   // Send all comics, regardless of if they were updated. Default: false.
   sendAllComics?: boolean;
@@ -87,115 +92,17 @@ const generateHtmlForComic = (
   return null;
 };
 
-// TODO(ecarrel): this is the worst. Replace this with a data-driven model,
-// connected to the "newsitems" table we already have.
-const customMessages: Record<string, string> = {
-  "May 27th, 2020": `
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Hi everyone,
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Thanks to those who wrote in to note that your comics weren't coming through yesterday or today! As comic fans ourselves, we recognize the small but substantial benefits a bit of humor can have first thing in the morning, especially considering these crazy times.
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    So, good news! We've found and fixed the problem (as you can see!). Note that the comics you're receiving in this email might be a couple days old while our system is still recuperating, but you should resume getting your comics as usual first thing tomorrow morning.
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    We greatly appreciated your patience as we figured this out. Your kind messages and thoughtful notes are inspiring, and remind us why we run this service, completely free and ad-free, in the first place!
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Hope everyone is staying safe. Remember to wash your hands often, wear masks, and practice good social-distancing habits— it could save lives!
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    All the best,<br />
-    Gabe and Elijah<br />
-    Team Inbox Comics
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Without further ado, here are today's comics.
-</p>
-`,
-  "March 23rd, 2021": `
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Hi everyone,
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    As many of you noted, several of our most popular comics (including Zits, Hagar the Horrible, Beetle Bailey, and others) weren't updating since last Wednesday. We have now fixed the issue and comics should be coming through as normal. 
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Enjoy your comics, stay safe, and (if and when it is available to you) be sure to get vaccinated!
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    All the best,<br />
-    Gabe and Elijah<br />
-    Team Inbox Comics
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Without further ado, here are today's comics.
-</p>
-`,
-  "May 25th, 2021": `
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Hi everyone,
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    As many of you noted, several of our most popular comics (including Dilbert, Mutts, and others) weren't updating correctly since last Wednesday. Sorry about this! We have now fixed the issue and comics should be coming through as normal.
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Cheers,<br />
-    Gabe and Elijah<br />
-    Team Inbox Comics
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Without further ado, here are today's comics.
-</p>
-`,
-  "August 9th, 2022": `
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Hi all,
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    It’s been a while since we shared an Inbox Comics update with you all— or more accurately, a while since we’ve had an issue to write about!
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    We wanted to send a quick note to say that we know some of you received multiple (or 113…) emails from us yesterday, but the problem has been identified and should now be fixed. One of the services we use to send emails apparently failed to report the messages as “sent,” so our other service just kept them coming. But don’t worry, this should be the only email you receive from us today!! 😊
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Thanks to everyone who wrote us about the problem. For our newer subscribers, we’re a two-person team who work on Inbox Comics in our spare time, and fund the service and email delivery out of pocket (and we promise never to sell your data or put ads in our emails!).
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    We don’t have any other updates to share at this time, except to say that we’re still excited about this passion project and will continue running the site for as long as we can! Thanks for your patience with us and for your continued support.
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Please let us know if you continue to have issues.
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    All the best,<br />
-    Elijah and Gabe,<br />
-    Team Inbox Comics
-</p>
-`,
-  "March 2nd, 2023": `
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Hi all,
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    We wanted to let you know that in light of deeply offensive comments recently made by Dilbert creator Scott Adams, we have decided to remove Dilbert from the Inbox Comics platform. We know Dilbert is a favorite comic for many of you as well as for us, and we do not make this decision lightly. We reached this decision with input from the Inbox Comics community, and we welcome all thoughts and concerns moving forward as well. Here's to hoping that the gap some of you will see in your morning emails makes way for a new favorite comic strip you can enjoy!
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    All the best,<br />
-    Elijah and Gabe,<br />
-    Team Inbox Comics
-</p>
-<p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
-    Without further ado, here are today's comics.
-</p>
-`,
+const formatEmailContentForNewsItem = (emailContent: string): string => {
+  return emailContent.replace(
+    /<p>/g,
+    "<p style=\"font - family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;\">",
+  );
 };
 
 export const sendComicEmail = async (
   email: string,
   comics: ComicForEmail[],
+  newsItem: NewsItemForEmail | null,
   options: SendComicEmailOptions = {},
   date: Moment = now(),
   googleAnalyticsHash: string = uuidv4(),
@@ -214,8 +121,8 @@ export const sendComicEmail = async (
   <p style="font-family: Palatino, 'Palatino Linotype', 'Book Antiqua', Georgia, serif;">
     Good morning! Here are today's comics.
   </p>`;
-  if (customMessages[formattedDate] != null) {
-    message = customMessages[formattedDate];
+  if (newsItem != null) {
+    message = formatEmailContentForNewsItem(newsItem.emailContent);
   }
   const body = `<html>
 <head>

--- a/components/ResendEmailLink/ResendTodaysEmailLink.tsx
+++ b/components/ResendEmailLink/ResendTodaysEmailLink.tsx
@@ -52,6 +52,7 @@ export const ResendTodaysEmailLink = (props: Props) => {
           sendAllComics: true,
           mentionNotUpdatedComics: true,
           onlyIfWeHaventCheckedToday: false,
+          includeLatestNewsItemEvenIfItsAlreadyBeenSent: false,
         },
       },
     });


### PR DESCRIPTION
Added some new fields to news items:
- isPublished
- emailContent

... and added some email-sending logic so that the latest news entry goes out in tomorrow's email (unless that user has already gotten that news entry).

Separately, created a retool dashboard (live now for staging at https://inboxcomics.retool.com/apps/94b543f2-b9d6-11ed-96c8-77f19916afaf) which we can use to add/edit news entries from here on out.