### PR TITLE
Make dependabot only run monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "npm"
     directory: "/api/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Lots of P.R.s = lots of eventual merges = lots of automated deployments to Vercel = coming close to the Vercel deployment limits for the hobby plan