### PR TITLE
compile backend as commonjs

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "esnext",
+    "module": "commonjs",
     "jsx": "preserve",
     "lib": ["dom", "es2017"],
     "moduleResolution": "node",


### PR DESCRIPTION
Fixes #81. This allows us to remove the `VERCEL_CLI_VERSION=vercel@28.10.2` environment variable which we were setting as a workaround per https://github.com/orgs/vercel/discussions/1225#discussioncomment-4631126.

Did not expect this to be so easy. We could have done this months ago 😅.