### PR TITLE
update gitignore for vercel >= 30.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bundle
 tsconfig.tsbuildinfo
 next-env.d.ts
 .vscode
+.env*.local


### PR DESCRIPTION
Per https://github.com/vercel/vercel/releases/tag/vercel%4030.0.0, vercel CLI >= 30.0.0 now pulls environment variables to `.env.local` rather than to `.env`, necessitating a `.gitignore` change. I recently locally upgraded past 30.0.0 as part of #181 / #81.