### PR TITLE
Revert "upgrade mongo to 7"

### DIFF
--- a/infra/mongodb.tf
+++ b/infra/mongodb.tf
@@ -7,7 +7,6 @@ resource "mongodbatlas_cluster" "inbox_comics" {
   backing_provider_name = "AWS"
   provider_region_name = "US_WEST_2"
   provider_instance_size_name = "M0"
-  mongo_db_major_version = "7.0"
 
   auto_scaling_disk_gb_enabled = false
 }


### PR DESCRIPTION
Reverts elijahcarrel/inbox-comics#230

Because executing terraform failed with

> Error: error updating MongoDB Cluster (inbox-comics-staging-0): error updating MongoDB Cluster (inbox-comics-staging-0): PATCH <redacted> 400 (request "TENANT_CLUSTER_UPDATE_UNSUPPORTED") Cannot update a M0/M2/M5 cluster through the public API.