### PR TITLE
add infra to vercelignore

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+infra


### PR DESCRIPTION
The `vercel` command wasn't working on my local because it was needlessly uploading 300+ MB of terraform. Excludes the whole `infra` directory from upload to vercel, as that directory is not needed for vercel deployments.