### PR TITLE
fix arcamax scraper

### DIFF
--- a/api/src/service/scraper/scrapers/arcamax.ts
+++ b/api/src/service/scraper/scrapers/arcamax.ts
@@ -30,10 +30,10 @@ export class ArcamaxScraper extends Scraper {
       return scrapeFailure(failureModes.ARCAMAX_REJECTION);
     }
     const comicImages = $("img#comic-zoom");
-    if (comicImages.length !== 1) {
+    if (comicImages.length < 1) {
       return scrapeFailure(failureModes.ARCAMAX_MISSING_IMAGE_ON_PAGE);
     }
-    const imageUrl = comicImages.attr("src");
+    const imageUrl = comicImages.first().attr("src");
     return scrapeSuccess(imageUrl);
   }
 }


### PR DESCRIPTION
Fixes #299 I think. Looks like:
1. We fail if there is more than one match
2. They added a "Other Comics You May Like" section which also started matching

There's no great way I can immediately see to not select the "Other Comics You May Like" section, so this is a hacky fix for now to just return the first result.