### PR TITLE
upgrade terraform providers to current major releases

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,25 +1,67 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.16.1"
-  constraints = "~> 5.16"
+provider "registry.terraform.io/checkly/checkly" {
+  version     = "1.22.0"
+  constraints = "~> 1.0"
   hashes = [
-    "h1:vzzDRBmLkqTRH9j7W2odBL2SZbumUEBLKH7QNWqT8OM=",
-    "zh:0d313783ae3abe06387b28b8c9f9b363f7b9cc3cecb7af879220f218a34d6463",
-    "zh:35bdb7a69f418dc71e3aa7217bacc4849dea33889d338d76f0a2bcc691073843",
-    "zh:38ec5e1220caccec76855084971a88a08cb2dc3ed33ace5399d8a1785982b935",
-    "zh:4b635ae8e21edc9deb9a83c4e1c8d1bfc9482ad930d18ba22047402d54d7edad",
-    "zh:4cf88464ab0fdbd3e21795593930a81c21ce573c279fa58be23d40005625196c",
-    "zh:5b52f24bd51b31b466f83243a6e3f1744bfad3e87989db47c2a6cc4c7b9d5141",
-    "zh:5ffc79bd15889b9232b226a29b3431659e1a30c476178dc9b59af5b7f35ac5fb",
-    "zh:64630c725983161ad99f97f1aabc0106a1f4710805fe4b5b27b8642ddad56cf5",
-    "zh:8f27b067e565c4a884f99cfa1eadeae60cc7535cdf2189de529df41b9c2b95c6",
-    "zh:97e72c4ed08c3176446464ebffde3b1304848fb9c762b14bce16a5e9d7ae3c96",
+    "h1:zkSxzVDgskoJtDcoVM+4Ti8Xjuwb1RbDVSIgCoXeZqA=",
+    "zh:1eff7f267ec7841a176e9fef7d7708709cf9d3f3360e6e5158bbdf7bc4b1c466",
+    "zh:20baa02d244ccc6a6101e99afe052f919a6aa1bbde7a8bd1e1cecca8537634de",
+    "zh:21f52b7a22cc1fda16d25ffb7ad3d0a4dae792fdbf5ce88661d1873e1441723d",
+    "zh:32985662c0f07c6e834257a47bcfabe8c88ca28c8a558febe47ef774bb3b1c63",
+    "zh:32a034c20826a30eda73a613d57632239a19e30e674f5c5257bf67e1937a617f",
+    "zh:32aced7eea2af71ca31ffaabec8dcd60444850235f1d45779c7d7566f222dd41",
+    "zh:333d7d1f22bcae3b61293adcdf398dddc4b63d9ac35f96153025f5411f52a1df",
+    "zh:4fbb7e95c1a4d4338c4fe2d6f3ecb989d4a7d2f5c347df1bb8ec19e5e80763e6",
+    "zh:6165fa6b8fba6f4bc455cf4dda11ef98ecd72c7769a9d0643008ef644413ecee",
+    "zh:914734403a53aebcbaa1aa36b7aafaa36ee2ca02f1de04b05c49f45904b97339",
+    "zh:bc06ece72500a9a5215d0af47cee140a97772affa6b942d63757e3a71f702af9",
+    "zh:c2858743890306efa0a684ba14788ee0dc6ae873b362f5a9a6ed942239b1a506",
+    "zh:c992109512216405840bc531ac7c9d4882782366e492ff8507015882789bacfc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "6.44.0"
+  hashes = [
+    "h1:NYUMqeKfML2PtEyC5Ob/g44PkxIzoKBsNSftrZvRY24=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a53a76386100ad69a406ca80e04152fcb0a63ae12b55b0c876ae007e11627a9e",
-    "zh:c9b864cd00d79c5ce8807673f4a6e386f44ff49bbdb56ee51086b403dc064347",
-    "zh:e139f7d6ed11fa72838b77898e6dff70f3d001ff37369a83f575e658b1912054",
-    "zh:e68cd728ed67bf4dc5e7c0e3e3082b732c768fd459a23ae6f691ac734d59b9c7",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}
+
+provider "registry.terraform.io/mongodb/mongodbatlas" {
+  version     = "2.12.0"
+  constraints = ">= 1.12.1"
+  hashes = [
+    "h1:Pfbzo8if9IzShxSr2bblU+gOhsd2GII8QA1IKFg9jXc=",
+    "zh:085949d1ce2a46dfba3db77c7f928090a8dd4028737589dfff1186f9821f6fd6",
+    "zh:0e8fc61f276a96985c0e98392a1a3e619a17be8a14133201a7753d74a0e47cdd",
+    "zh:13cc3590469620a14e14f9a4bf73c814af835f7cc1431517b086388d37aa5045",
+    "zh:2d251eea86b3b31d61c78d86e84fe3082d6919ba0b73e1566c3d754dc34a274c",
+    "zh:4fe1aaaeb244e5d81b4ac7c56a5e73c50b023a26b4ae3eff9b2abb4a0e237bb8",
+    "zh:6e288bdb89fc6e4ac33200dde06f78a66a4ef798dc1bd124d5ffc7a627c9b398",
+    "zh:6ede993821a9e5cdef6db59d4e97d9ebe6145c07dbbe866103b6ec437fd5210e",
+    "zh:8afab3d77eb7f47f415cff3fe9bbb400bf6743e3f0ecfd339082e87ce8422965",
+    "zh:c00e4876e1a74bc56b0f0f457a736074610616b1b5c7e23e2c2dec548d13f379",
+    "zh:c5ed99bb85a33b1d900881ccad19c70a7202904c4442a0a6e5cda21366ea458c",
+    "zh:d808bcc67f1daf73273a0133b9776e6dde0028bd7fd8624326f4ce01e9853dcb",
+    "zh:d88dbbd77632b44df65b53991ea84445558c931dd7ea3a876e28d769d6df931d",
+    "zh:ec88e2ffd77a6811279c0e448e5fc05399da89b06b599e4abaca5997a6a91b2f",
   ]
 }

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -24,7 +24,7 @@ provider "registry.terraform.io/checkly/checkly" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.44.0"
-  constraints = "6.44.0"
+  constraints = "~> 6.0"
   hashes = [
     "h1:NYUMqeKfML2PtEyC5Ob/g44PkxIzoKBsNSftrZvRY24=",
     "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
@@ -47,7 +47,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/mongodb/mongodbatlas" {
   version     = "2.12.0"
-  constraints = ">= 1.12.1"
+  constraints = "~> 2.0"
   hashes = [
     "h1:Pfbzo8if9IzShxSr2bblU+gOhsd2GII8QA1IKFg9jXc=",
     "zh:085949d1ce2a46dfba3db77c7f928090a8dd4028737589dfff1186f9821f6fd6",

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
   }
 
-  required_version = ">= 1.5.7"
+  required_version = ">= 1.10.0"
 }
 
 provider "aws" {

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.16"
+      version = "~> 6.0"
     }
 
     mongodbatlas = {
       source = "mongodb/mongodbatlas"
-      version = ">= 1.12.1"
+      version = "~> 2.0"
     }
 
     checkly = {


### PR DESCRIPTION
Refreshes the Terraform lockfile to resolve the expired aws provider signing key in CI while keeping provider constraints flexible for future side-project updates.